### PR TITLE
Add guidance on working in the open

### DIFF
--- a/docs/guides/dos-and-donts-for-open-project-boards.md
+++ b/docs/guides/dos-and-donts-for-open-project-boards.md
@@ -1,0 +1,19 @@
+---
+title: Dos and don’ts for open project boards
+---
+
+Opening up your project or Kanban boards invites our users, partners and stakeholders to see our work and make contributions. For example, we can share a task with a colleague in Slack or show a stakeholder that we're working on something. It's one of the benefits of [working in the open](/how-we-work/working-in-the-open/).
+
+There's some basic hygiene for working on open project boards which has helped teams like [GOV.‌UK Design System](https://github.com/orgs/alphagov/projects/53) engage with users and stakeholders for years.
+
+## Dos and dont's 
+
+- **Remind yourself of security and confidentiality responsibilities.** Check the MHCLG intranet for guidance on [security and confidentiality](https://intranet.communities.gov.uk/handbook/contents/security-data-and-confidentiality/security-and-confidentiality/) and [the need for greater openness in the work of government](https://intranet.communities.gov.uk/handbook/contents/security-data-and-confidentiality/use-of-official-publications/#Introduction).
+- **Quickly read up on [security classifications](https://www.gov.uk/government/publications/government-security-classifications/government-security-classifications-policy-quick-read-html).** Most of our work falls under OFFICIAL status. Some of it may be sensitive, but the majority of delivery work isn't. We rarely work on anything SECRET.
+- **If you need to use someone's name, don't write out full names.** Use someone's first name and the intial of their surname, plus their organisation – Joe S, Borchester – if you need to refer to a person. Lots of people share their full names, job titles and who they work for on LinkedIn, but not everyone. (You can use someone's GitHub handle, e.g. @stevenjmesser, without permission.)
+- **Use access control on documents and links you share.** Use sharing settings to send a document or link to a specific person, controlling who can access it. Don't give access to the outside world by default.
+- **Don't comment on individuals or organisations in an objectionable way.** You're representing MHCLG and the department, so don't say anything that would bring our work into disrepute. (You can share grumbles and opinions in a safe, closed space like Slack.)
+- **Be clear, give context.** Your team-mates need clarity to be effective. You may only need to neuter your words if there's a security risk, privacy risk or a delicate relationship to maintain.
+- **If you're working on something that's already mentioned in the public domain, you can talk about it openly.** Just make sure to follow the other dos and don'ts. 
+- **Add issues to a private repo if anything must remain hidden.** A GitHub project board can show issues from multiple repositories. You can add issues to a private repo if needs be, and this will keep information hidden. It's probably sensible to keep policy-related matters in access-controlled documents and emails, to protect against leaks.
+- **You can still make mistakes.** We know that no one is perfect and new ways of working can take time to get used to. You probably won't make any big mistakes or release confidential information, but ask your service owner if unsure.

--- a/docs/how-we-work/working-in-the-open.md
+++ b/docs/how-we-work/working-in-the-open.md
@@ -1,0 +1,77 @@
+---
+title: Working in the open
+---
+
+<!-- With thanks to Emily Webber for her contribution to this guide! -->
+
+Working in the open has been one of the team’s core values since the very beginning. We’re open and accountable. We publish our code in the open, we write about what we do, and we invite others in.
+
+## Why work in the open?
+
+One of the Government Design Principles is [make things open: it makes things better](https://www.gov.uk/guidance/government-design-principles#make-things-open-it-makes-things-better).
+
+Open and agile communication from everyone across the programme can help keep users, people, teams, other organisations and stakeholders interested, engaged and up-to-date about what we are doing. 
+
+Talking about our work openly – not hiding it or making it hard to find – increases our reach and invites people to join the conversation. It brings [participation, agility, momentum, leverage and better feedback loops](https://visitmy.website/2020/01/25/blogging-working-open/#whats-the-point-of-being-open).
+
+Similarly, making [our code](https://github.com/digital-land/), [roadmaps](https://www.planning.data.gov.uk/about/roadmap), [performance](https://www.planning.data.gov.uk/about/performance) and [project boards](https://github.com/orgs/digital-land/projects) available helps people see what we’ve done, what we’re doing, and where we’re going. They're welcomed to [get involved](https://design.planning.data.gov.uk/how-to-contribute-to-the-data-design-process), [submit pull requests](https://github.com/digital-land/digital-land.github.io/pull/7), ask questions and [provide helpful information](https://github.com/digital-land/data-standards-backlog/discussions/25#discussioncomment-6678177). 
+
+It also works as a great recruitment tool, exciting and inspiring new talent to join our mission.
+
+This short guide is meant to help share the why, what, and how of working in the open.
+
+**Our comms should**
+
+* be simple, clear, brief and regular  
+* come from everyone  
+* move as fast as the work does  
+* show the actual work  
+* build a long-term narrative  
+* celebrate all wins  
+* use the human voice
+
+In general, 99% of delivery work should be open.
+
+## What should I talk about?
+
+Sharing milestones and achievements is always good, but working in the open creates stories out of day-to-day work – sharing what we did and how we did it. So, rather than building up to big announcements, you can share more of what you did along the way. 
+
+### You can talk about
+| &nbsp; | &nbsp; |
+| --- | --- |
+| **Something we did for users.** Include how it helped them, what you learnt, photos and quotes. | **A knotty problem we unpicked.** Include details on the problem, its size, why solving it was important, what you did, and the outcome for users or your team. 
+| **How we changed our mind.** Include initial assumptions, what you learnt, and what decisions the new thinking has enabled. | **How we approach things as a team (our ways of working).** Include new methods and techniques, technical notes, design principles and documentation. |
+
+## Be careful not to talk about
+
+Aim to be as open as you can, but remember that you should not share:
+
+* anything classified as secret or top secret  
+* anything a Minister or senior civil servant should or will be announcing  
+* anything that breaks the Civil Service Code  
+* any personal information about anyone without their permission
+
+If in doubt, ask your service owner. 
+
+Read the guide on [simple dos and don'ts for open project boards](/guides/dos-and-donts-for-open-project-boards/).
+
+## Types of communication
+
+* Blog posts (open) *(see [Digital Land blog, Planning Data](https://digital-land.github.io/blog-post/) or [MHCLG Digital blog](https://mhclgdigital.blog.gov.uk))*  
+* Weeknotes (very open and regular) *(see our [\#weeknotes channel](https://communities-govuk.slack.com/archives/CTRF3SUBH))*  
+* LinkedIn (open-ish, requires a login) *(see [Digital Planning on LinkedIn](https://www.linkedin.com/posts/digital-planning-uk-gov_planning-officer-in-england-were-seeking-activity-7194632974963802113-3B1K))*  
+* Show and tells (can be open, often internal) *(see [MHCLG](https://www.youtube.com/channel/UCXoDA_N1xDFanzRb332aBqQ), [NHS 111 Online](https://111online.github.io/nhs111-resources/111online/show-and-tells/) and [GDS](https://www.youtube.com/watch?v=A6NAPQVwNOc))*  
+* Newsletters (open-ish) *(see [Open Digital Planning newsletter](https://uk.linkedin.com/company/open-digital-planning?trk=public_post_feed-actor-name) )*  
+* Backlogs and roadmaps (very open) *(see [The case for public backlogs and roadmaps, Public Digital](https://public.digital/pd-insights/blog/2024/07/filling-in-the-gaps-the-case-for-public-backlogs-roadmaps))*  
+* Service performance pages (very open) *(see [Planning Data performance](https://www.planning.data.gov.uk/about/performance), [GOV.UK Pay performance](https://www.payments.service.gov.uk/performance/), [Register to Vote performance](https://www.registertovote.service.gov.uk/performance))*
+* Events and conferences (open-ish, limited and irregular) *(see [Matt Wood Hill at SD in Gov](https://govservicedesign.net/programme/how-intervene-broken-markets-systems-approach-planning), [GOV.UK Design System Day](https://design-system.service.gov.uk/community/design-system-day/))*
+
+## Further reading and inspiration
+
+* Matt Wood-Hill from Software wrote this excellent piece on [what it means to be open in this programme](https://www.linkedin.com/pulse/what-we-mean-open-digital-planning-open-digital-planning-wzeve)  
+* Different blog post [formats](https://www.usethehumanvoice.com/formats/)  
+* [How to write a great blog post](https://intranet.levellingup.gov.uk/task/internal-communications/write-a-great-blog-post/) (MHCLG Intranet)  
+* [A guide to agile communication, DEFRA Digital blog](https://defradigital.blog.gov.uk/a-guide-to-agile-communication/)   
+* [Guide on doing weeknotes](https://doingweeknotes.com/) (plus examples of what good looks like)  
+* [Guide on doing show & tells](https://boringmagi.cc/2025/01/30/tips-on-doing-show-and-tell-well/)
+* [Why people write weeknotes](https://visitmy.website/2020/11/01/why-i-write-weeknotes/)


### PR DESCRIPTION
Working in the open has been happening across the public sector for nearly a decade. It brings a whole host of benefits, but it also introduces a new way of working. This guidance aims to show how to do it well and safely.

I’ll share this pull request with a few people for review. It’d be great if people could make comments and ask questions, particularly on anything that’s unclear or may be missing. 

I’d especially like views from our Policy colleagues who will be very helpful in shaping this into something usable.